### PR TITLE
Work towards Gentoo build

### DIFF
--- a/Makefile.sub
+++ b/Makefile.sub
@@ -11,7 +11,7 @@ build:
 
 .PHONY: update
 update:
-	docker pull gentoo/stage3
+	docker pull gentoo/stage3:desktop
 
 .PHONY: test
 test:

--- a/Makefile.sub
+++ b/Makefile.sub
@@ -7,11 +7,13 @@ BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
 .PHONY: build
 build:
+	cp -r ../Pillow/depends .
+	cp test.sh depends
 	docker build -t $(IMAGENAME):$(BRANCH) .
 
 .PHONY: update
 update:
-	docker pull gentoo/stage3:desktop
+	./update.sh
 
 .PHONY: test
 test:
@@ -28,4 +30,3 @@ clean:
 .PHONY: shell
 shell:
 	docker run --rm -it -v $(ROOT):/Pillow $(IMAGENAME):$(BRANCH) /bin/bash
-

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -22,6 +22,10 @@ RUN emerge --quiet -uDU @world
 # Install some useful bits.
 RUN emerge --quiet --oneshot --jobs=$(nproc) media-libs/libjpeg-turbo sys-libs/zlib app-text/ghostscript-gpl 
 
+# We're not running on real hardware, so set basic values instead.
+# We deliberately set this quite late on to avoid rebuilding e.g. mesa.
+RUN echo 'VIDEO_CARDS="fbdev dummy"' | cat >> /etc/portage/make.conf
+
 # Try install as many of our (test) dependencies as possible with fewer flags on
 RUN emerge --quiet --oneshot --onlydeps --jobs=$(nproc) --with-test-deps dev-python/pillow || true
 
@@ -31,4 +35,17 @@ RUN USE="jpeg jpeg2k tiff truetype xvfb X elogind" emerge --quiet --oneshot --on
 
 # Actually build & run the tests.
 # TODO: change this to use the mounted version of Pillow (so the commit to be tested)
-RUN FEATURES="test" USE="jpeg jpeg2k tiff truetype xvfb X elogind" emerge --verbose --oneshot --getbinpkg=n dev-python/pillow
+#RUN FEATURES="test" USE="jpeg jpeg2k tiff truetype xvfb X elogind" emerge --verbose --oneshot --getbinpkg=n dev-python/pillow
+
+RUN emerge --quiet --jobs=$(nproc) dev-python/virtualenv x11-misc/xvfb-run
+
+ADD depends /depends
+RUN cd /depends
+
+RUN useradd pillow \
+    && virtualenv --system-site-packages /vpy3 \
+    && /vpy3/bin/pip install --no-cache-dir --upgrade pip \
+    && chown -R pillow:pillow /vpy3
+
+USER pillow
+CMD ["depends/test.sh"]

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -1,10 +1,34 @@
-FROM gentoo/stage3
+FROM gentoo/stage3:desktop
 
-RUN echo 'USE="xvfb X elogind"' | cat >> /etc/portage/make.conf
+# Disable bits which don't work within Docker.
 RUN echo 'FEATURES="-ipc-sandbox -pid-sandbox -network-sandbox -usersandbox -mount-sandbox -sandbox"' | cat >> /etc/portage/make.conf
-RUN cat /etc/portage/make.conf
-RUN emerge --quiet --sync || true
-RUN emerge -v1 dev-lang/rust-bin
-RUN emerge media-libs/libjpeg-turbo sys-libs/zlib app-text/ghostscript-gpl
-RUN USE="jpeg jpeg2k tiff truetype xvfb X elogind" emerge -v1 --with-test-deps dev-python/pillow
-RUN FEATURES=test USE="jpeg jpeg2k tiff truetype xvfb X elogind" emerge -v1 dev-python/pillow
+# Speed things up a bit.
+RUN echo 'FEATURES="${FEATURES} parallel-install parallel-fetch -merge-sync"' | cat >> /etc/portage/make.conf
+
+# TODO: May be able to drop this once changed to desktop docker images?
+# https://dilfridge.blogspot.com/2021/09/experimental-binary-gentoo-package.html
+RUN echo -e "[binhost]\npriority = 9999\nsync-uri = https://gentoo.osuosl.org/experimental/amd64/binpkg/default/linux/17.1/x86-64/\n" | cat >> /etc/portage/binrepos.conf
+
+RUN echo 'EMERGE_DEFAULT_OPTS="--binpkg-respect-use=n --getbinpkg=y --autounmask-write --autounmask-continue --autounmask-keep-keywords=y --autounmask-use=y"' | cat >> /etc/portage/make.conf
+RUN echo 'USE="elogind -polkit"' | cat >> /etc/portage/make.conf
+RUN cat /etc/portage/make.conf                                                  
+
+RUN emerge-webrsync --quiet || true 
+RUN eselect news read --quiet all || true
+
+# Make sure everything is consistent first.
+RUN emerge --quiet -uDU @world
+
+# Install some useful bits.
+RUN emerge --quiet --oneshot --jobs=$(nproc) media-libs/libjpeg-turbo sys-libs/zlib app-text/ghostscript-gpl 
+
+# Try install as many of our (test) dependencies as possible with fewer flags on
+RUN emerge --quiet --oneshot --onlydeps --jobs=$(nproc) --with-test-deps dev-python/pillow || true
+
+# Then install the remaining (test) dependencies with more flags (because they clearly didn't get picked up before)
+# ... and these more flags are needed to run tests anyway.
+RUN USE="jpeg jpeg2k tiff truetype xvfb X elogind" emerge --quiet --oneshot --onlydeps --with-test-deps --getbinpkg=n dev-python/pillow
+
+# Actually build & run the tests.
+# TODO: change this to use the mounted version of Pillow (so the commit to be tested)
+RUN FEATURES="test" USE="jpeg jpeg2k tiff truetype xvfb X elogind" emerge --verbose --oneshot --getbinpkg=n dev-python/pillow

--- a/gentoo/test.sh
+++ b/gentoo/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+source /vpy3/bin/activate
+cd /Pillow
+pip install pytest
+make clean
+make install-coverage
+python3 -c "from PIL import Image"
+QT_QPA_PLATFORM=offscreen /usr/bin/xvfb-run -a pytest -vx --cov PIL --cov-report term Tests

--- a/gentoo/update.sh
+++ b/gentoo/update.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker pull gentoo/stage3:desktop


### PR DESCRIPTION
@radarhere I've got to the point where a build takes ~10m (including running Pillow's test suite). Needs more work to run Pillow from the mount i.e. /Pillow where the repo-state-to-be-tested-is but that part shouldn't be too bad.

Hopefully this is useful. I'm working on getting the s390x stages up to date so those can possibly be used via Docker too.